### PR TITLE
Add commit-file-type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ In cases where more dynamic customization is sensible, suitable environment vari
 
 Any option without a default is required.
 
-| Option                | Definition                                                          | Type      | Default      | Supports dynamic modification |
-|-----------------------|---------------------------------------------------------------------|-----------|--------------|-------------------------------|
-| `build-backend`       | The wrapped build backend (e.g. `setuptools.build_meta`)            | string    |              | N                             |
-| `commit-file`         | The file in which to write `__git_commit__`                         | string    | "" (No file) | N                             |
-| `disable-cuda-suffix` | If true, don't try to write CUDA suffixes                           | bool      | false        | Y                             |
-| `only-release-deps`   | If true, do not append alpha specifiers to dependencies             | bool      | false        | Y                             |
-| `require-cuda`        | If false, builds will succeed even if nvcc is not available         | bool      | true         | Y                             |
-| `requires`            | List of build requirements (in addition to `build-system.requires`) | list[str] | []           | N                             |
+| Option                | Definition                                                               | Type      | Default      | Supports dynamic modification |
+|-----------------------|--------------------------------------------------------------------------|-----------|--------------|-------------------------------|
+| `build-backend`       | The wrapped build backend (e.g. `setuptools.build_meta`)                 | string    |              | N                             |
+| `commit-file`         | The file in which to write the commit                                    | string    | "" (No file) | N                             |
+| `commit-file-type`    | The type of file in which to write the commit (one of `python` or `raw`) | string    | "python"     | N                             |
+| `disable-cuda-suffix` | If true, don't try to write CUDA suffixes                                | bool      | false        | Y                             |
+| `only-release-deps`   | If true, do not append alpha specifiers to dependencies                  | bool      | false        | Y                             |
+| `require-cuda`        | If false, builds will succeed even if nvcc is not available              | bool      | true         | Y                             |
+| `requires`            | List of build requirements (in addition to `build-system.requires`)      | list[str] | []           | N                             |
 
 
 ## Outstanding questions

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -12,12 +12,13 @@ class Config:
     # required) and whether it may be overridden by an environment variable or a config
     # setting.
     config_options = {
-        "build-backend": (None, False),
-        "commit-file": ("", False),
-        "disable-cuda-suffix": (False, True),
-        "only-release-deps": (False, True),
-        "require-cuda": (True, True),
-        "requires": ([], False),
+        "build-backend": (None, False, None),
+        "commit-file": ("", False, None),
+        "commit-file-type": ("python", False, {"python", "raw"}),
+        "disable-cuda-suffix": (False, True, None),
+        "only-release-deps": (False, True, None),
+        "require-cuda": (True, True, None),
+        "requires": ([], False, None),
     }
 
     def __init__(self, dirname=".", config_settings=None):
@@ -31,7 +32,7 @@ class Config:
     def __getattr__(self, name):
         config_name = name.replace("_", "-")
         if config_name in Config.config_options:
-            default_value, allows_override = Config.config_options[config_name]
+            default_value, allows_override, allowed_values = Config.config_options[config_name]
 
             # If overrides are allowed environment variables take precedence over the
             # config_settings dict.
@@ -47,15 +48,15 @@ class Config:
                                 f"{env_var} must be 'true' or 'false', not {str_val}"
                             )
                         return str_val == "true"
-                    return os.environ[env_var]
+                    return self._check_value(env_var, os.environ[env_var], allowed_values)
 
                 if config_name in self.config_settings:
                     if isinstance(default_value, bool):
                         return self.config_settings[config_name] == "true"
-                    return self.config_settings[config_name]
+                    return self._check_value(config_name, self.config_settings[config_name], allowed_values)
 
             try:
-                return self.config[config_name]
+                return self._check_value(config_name, self.config[config_name], allowed_values)
             except KeyError:
                 if default_value is not None:
                     return default_value
@@ -63,3 +64,9 @@ class Config:
                 raise AttributeError(f"Config is missing required attribute {name}")
         else:
             raise AttributeError(f"Attempted to access unknown option {name}")
+
+    def _check_value(self, name, value, allowed_values):
+        if allowed_values is not None and value not in allowed_values:
+            formatted_list = "\n".join(f" - {v}" for v in allowed_values)
+            raise ValueError(f"{name} must be one of:\n{formatted_list}")
+        return value

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -235,32 +235,46 @@ def _edit_git_commit(config):
     at build time.
     """
     commit_file = config.commit_file
+    commit_file_type = config.commit_file_type
     commit = _get_git_commit()
 
     if commit_file != "" and commit is not None:
         bkp_commit_file = f".{os.path.basename(commit_file)}.rapids_build_backend.bak"
         try:
-            with open(commit_file) as f:
-                lines = f.readlines()
+            if commit_file_type == "python":
+                with open(commit_file) as f:
+                    lines = f.readlines()
 
-            shutil.move(commit_file, bkp_commit_file)
+                shutil.move(commit_file, bkp_commit_file)
 
-            with open(commit_file, "w") as f:
-                wrote = False
-                for line in lines:
-                    if "__git_commit__" in line:
+                with open(commit_file, "w") as f:
+                    wrote = False
+                    for line in lines:
+                        if "__git_commit__" in line:
+                            f.write(f'__git_commit__ = "{commit}"\n')
+                            wrote = True
+                        else:
+                            f.write(line)
+                    # If no git commit line was found, write it at the end of the file.
+                    if not wrote:
                         f.write(f'__git_commit__ = "{commit}"\n')
-                        wrote = True
-                    else:
-                        f.write(line)
-                # If no git commit line was found, write it at the end of the file.
-                if not wrote:
-                    f.write(f'__git_commit__ = "{commit}"\n')
+
+            elif commit_file_type == "raw":
+                try:
+                    shutil.move(commit_file, bkp_commit_file)
+                except FileNotFoundError:
+                    bkp_commit_file = None
+
+                with open(commit_file, "w") as f:
+                    f.write(f'{commit}\n')
 
             yield
         finally:
             # Restore by moving rather than writing to avoid any formatting changes.
-            shutil.move(bkp_commit_file, commit_file)
+            if bkp_commit_file:
+                shutil.move(bkp_commit_file, commit_file)
+            else:
+                os.unlink(commit_file)
     else:
         yield
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,10 @@ def setup_config_project(tmp_path, flag, config_value):
     [
         ("commit-file", '"pkg/_version.py"', "pkg/_version.py"),
         ("commit-file", None, ""),
+        ("commit-file-type", '"python"', "python"),
+        ("commit-file-type", '"raw"', "raw"),
+        ("commit-file-type", '"invalid"', ValueError),
+        ("commit-file-type", None, "python"),
         ("disable-cuda-suffix", "true", True),
         ("disable-cuda-suffix", "false", False),
         ("disable-cuda-suffix", None, False),
@@ -40,7 +44,11 @@ def setup_config_project(tmp_path, flag, config_value):
 )
 def test_config(tmp_path, flag, config_value, expected):
     config = Config(setup_config_project(tmp_path, flag, config_value))
-    assert getattr(config, flag.replace("-", "_")) == expected
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            getattr(config, flag.replace("-", "_"))
+    else:
+        assert getattr(config, flag.replace("-", "_")) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_impls.py
+++ b/tests/test_impls.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+import os.path
+import pytest
+import tempfile
+from unittest.mock import Mock, patch
+
+from rapids_build_backend.impls import _edit_git_commit
+
+
+@pytest.mark.parametrize(
+    ["commit_file_type", "initial_contents", "expected_contents"],
+    [
+        (
+            "python",
+            '# Begin Python file\n__git_commit__ = ""\n# End Python file\n',
+            '# Begin Python file\n__git_commit__ = "abc123"\n# End Python file\n',
+        ),
+        ("python", None, FileNotFoundError),
+        ("raw", "def456\n", "abc123\n"),
+        ("raw", None, "abc123\n"),
+    ],
+)
+@patch("rapids_build_backend.impls._get_git_commit", Mock(return_value="abc123"))
+def test_edit_git_commit(commit_file_type, initial_contents, expected_contents):
+    with tempfile.TemporaryDirectory() as d:
+        commit_file = os.path.join(d, "commit_file")
+        if initial_contents is not None:
+            with open(commit_file, "w") as f:
+                f.write(initial_contents)
+
+        config = Mock(
+            commit_file=commit_file,
+            commit_file_type=commit_file_type,
+        )
+        if isinstance(expected_contents, type) and issubclass(expected_contents, Exception):
+            with pytest.raises(expected_contents):
+                with _edit_git_commit(config):
+                    pass
+        else:
+            with _edit_git_commit(config):
+                with open(commit_file, "r") as f:
+                    assert f.read() == expected_contents
+
+        if initial_contents is not None:
+            with open(commit_file, "r") as f:
+                assert f.read() == initial_contents
+        else:
+            assert not os.path.exists(commit_file)


### PR DESCRIPTION
Add the ability to have commit-file be either a Python script or a "raw" file that contains only the Git commit.