### PR TITLE
Use allow-nightly-deps instead of only-release-deps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Any option without a default is required.
 
 | Option                | Definition                                                          | Type      | Default      | Supports dynamic modification |
 |-----------------------|---------------------------------------------------------------------|-----------|--------------|-------------------------------|
+| `allow-nightly-deps`  | If true, append alpha specifiers to dependencies                    | bool      | true         | Y                             |
 | `build-backend`       | The wrapped build backend (e.g. `setuptools.build_meta`)            | string    |              | N                             |
 | `commit-file`         | The file in which to write the git commit hash                      | string    | "" (No file) | N                             |
 | `disable-cuda-suffix` | If true, don't try to write CUDA suffixes                           | bool      | false        | Y                             |
-| `only-release-deps`   | If true, do not append alpha specifiers to dependencies             | bool      | false        | Y                             |
 | `require-cuda`        | If false, builds will succeed even if nvcc is not available         | bool      | true         | Y                             |
 | `requires`            | List of build requirements (in addition to `build-system.requires`) | list[str] | []           | N                             |
 

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -12,10 +12,10 @@ class Config:
     # required) and whether it may be overridden by an environment variable or a config
     # setting.
     config_options = {
+        "allow-nightly-deps": (True, True),
         "build-backend": (None, False),
         "commit-file": ("", False),
         "disable-cuda-suffix": (False, True),
-        "only-release-deps": (False, True),
         "require-cuda": (True, True),
         "requires": ([], False),
     }

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -142,7 +142,7 @@ def _add_cuda_suffix(req, cuda_suffix, cuda_major):
     return str(req)
 
 
-def _update_specifier(req):
+def _add_alpha_specifier(req):
     req = Requirement(req)
     if (
         req.name in _VERSIONED_RAPIDS_WHEELS or req.name in _UNVERSIONED_RAPIDS_WHEELS
@@ -185,10 +185,10 @@ def _process_dependencies(config, dependencies=None):
         )
 
     # Step 2: Allow nightlies of RAPIDS packages except in release builds. Do this
-    # before suffixing the names so that lookups in _update_specifier are accurate.
-    if not config.only_release_deps:
+    # before suffixing the names so that lookups in _add_alpha_specifier are accurate.
+    if config.allow_nightly_deps:
         dependencies = map(
-            _update_specifier,
+            _add_alpha_specifier,
             dependencies,
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,10 +46,10 @@ def test_config(tmp_path, flag, config_value, expected):
 @pytest.mark.parametrize(
     "flag, config_value, expected",
     [
-        ("disable-cuda-suffix", "true", True),
-        ("disable-cuda-suffix", "false", False),
         ("allow-nightly-deps", "true", True),
         ("allow-nightly-deps", "false", False),
+        ("disable-cuda-suffix", "true", True),
+        ("disable-cuda-suffix", "false", False),
         ("require-cuda", "true", True),
         ("require-cuda", "false", False),
     ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,14 +25,14 @@ def setup_config_project(tmp_path, flag, config_value):
 @pytest.mark.parametrize(
     "flag, config_value, expected",
     [
+        ("allow-nightly-deps", "true", True),
+        ("allow-nightly-deps", "false", False),
+        ("allow-nightly-deps", None, True),
         ("commit-file", '"pkg/_version.py"', "pkg/_version.py"),
         ("commit-file", None, ""),
         ("disable-cuda-suffix", "true", True),
         ("disable-cuda-suffix", "false", False),
         ("disable-cuda-suffix", None, False),
-        ("only-release-deps", "true", True),
-        ("only-release-deps", "false", False),
-        ("only-release-deps", None, False),
         ("require-cuda", "true", True),
         ("require-cuda", "false", False),
         ("require-cuda", None, True),
@@ -48,8 +48,8 @@ def test_config(tmp_path, flag, config_value, expected):
     [
         ("disable-cuda-suffix", "true", True),
         ("disable-cuda-suffix", "false", False),
-        ("only-release-deps", "true", True),
-        ("only-release-deps", "false", False),
+        ("allow-nightly-deps", "true", True),
+        ("allow-nightly-deps", "false", False),
         ("require-cuda", "true", True),
         ("require-cuda", "false", False),
     ],
@@ -73,10 +73,10 @@ def test_config_env_var(tmp_path, flag, config_value, expected):
 @pytest.mark.parametrize(
     "flag, config_value, expected",
     [
+        ("allow-nightly-deps", "true", True),
+        ("allow-nightly-deps", "false", False),
         ("disable-cuda-suffix", "true", True),
         ("disable-cuda-suffix", "false", False),
-        ("only-release-deps", "true", True),
-        ("only-release-deps", "false", False),
         ("require-cuda", "true", True),
         ("require-cuda", "false", False),
     ],


### PR DESCRIPTION
This PR renames the option `only-release-deps` to `allow-nightly-deps`. This inverts the logic (the default is `True` instead of `False`).
