### PR TITLE
Set secret names

### DIFF
--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -29,6 +29,13 @@ jobs:
       PUBLISH: "${{ inputs.publish }}"
     steps:
       - uses: actions/checkout@v4
+      - name: Set Proper Conda Upload Token
+        run: |
+          RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+          if rapids-is-release-build; then
+            RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_TOKEN }}
+          fi
+          echo "RAPIDS_CONDA_TOKEN=${RAPIDS_CONDA_TOKEN}" >> "${GITHUB_ENV}"
       - name: Python build
         run: "./ci/build_python.sh ${PUBLISH}"
   wheel-build:
@@ -38,6 +45,7 @@ jobs:
       image: rapidsai/ci-wheel:latest
     env:
       PUBLISH: "${{ inputs.publish }}"
+      RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
     steps:
       - name: checkout code repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Since this repo is not using `rapidsai/shared-workflows`, the secret tokens need to be set from the provided GHA secrets.

For conda uploads, the logic is adapted from https://github.com/rapidsai/shared-workflows/blob/branch-24.04/.github/workflows/conda-upload-packages.yaml#L80-L91

For wheel uploads, simply "rename" the secret just like https://github.com/rapidsai/shared-workflows/blob/branch-24.04/.github/workflows/wheels-publish.yaml#L78
