### PR TITLE
Upload from noarch directory.

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 
 UPLOAD_PACKAGES="${1:-false}"
 
-PKG_DIR="${PWD}/conda_package/"
+PKG_DIR="${PWD}/conda_package"
 rapids-conda-retry mambabuild --output-folder "${PKG_DIR}" conda/recipes/rapids-build-backend
 
 if [ "$UPLOAD_PACKAGES" = "true" ]; then
     # TODO: Figure out the best way to get CONDA_PKG_FILE
-    rapids-retry anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --label main --skip-existing --no-progress "${PKG_DIR}/*"
+    rapids-retry anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --label main --skip-existing --no-progress "${PKG_DIR}/noarch/*.tar.bz2"
 fi


### PR DESCRIPTION
This fixes conda package uploads, which are failing to find packages without the `noarch` directory.
