### PR TITLE
Update pre-commit-hooks to v0.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,10 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.0.2
+    rev: v0.0.3
     hooks:
       - id: verify-copyright
-        args: ["--main-branch", "main"]
+        args: [--fix, --main-branch=main]
 
 
 default_language_version:


### PR DESCRIPTION
This fixes an issue with how the `verify-copyright` hook handles multiple merge bases.