### PR TITLE
add mypy to linting checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 __pycache__
 .cache
+.mypy_cache/
+.ruff_cache/
 .vscode
 *.swp
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,15 @@ repos:
     hooks:
       - id: verify-copyright
         args: [--fix, --main-branch=main]
-
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.10.0'
+    hooks:
+      - id: mypy
+        args: [
+          "--config-file=pyproject.toml",
+          "rapids_build_backend/"
+        ]
+        pass_filenames: false
 
 default_language_version:
       python: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ license-files = ["LICENSE"]
 [tool.setuptools.packages.find]
 include = ["rapids_build_backend*"]
 
+[tool.mypy]
+ignore_missing_imports = true
+
 [tool.ruff]
 lint.select = ["E", "F", "W", "I", "N", "UP"]
 lint.fixable = ["ALL"]

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -11,11 +11,11 @@ if TYPE_CHECKING:
     # config options can be one of these types...
     config_val_type = str | bool | None
 
-    # ... or a callable that returns one of those or a list of strings
-    mutable_config_val_type = Callable[[], config_val_type | list[str]]
-    config_options_type = dict[
-        str, tuple[config_val_type | mutable_config_val_type, bool]
-    ]
+    # ... or a callable that returns one of those or some other mutable types
+    mutable_config_val_type = list[str]
+    config_val_callable = Callable[[], config_val_type | mutable_config_val_type]
+
+    config_options_type = dict[str, tuple[config_val_type | config_val_callable, bool]]
 
 
 class Config:

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -6,7 +6,16 @@ from typing import TYPE_CHECKING
 from .utils import _get_pyproject
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Callable
+
+    # config options can be one of these types...
+    config_val_type = str | bool | None
+
+    # ... or a callable that returns one of those or a list of strings
+    mutable_config_val_type = Callable[[], config_val_type | list[str]]
+    config_options_type = dict[
+        str, tuple[config_val_type | mutable_config_val_type, bool]
+    ]
 
 
 class Config:
@@ -15,7 +24,7 @@ class Config:
     # Mapping from config option to default value (None indicates that option is
     # required) and whether it may be overridden by an environment variable or a config
     # setting.
-    config_options: "dict[str, tuple[Any, bool]]" = {
+    config_options: "config_options_type" = {
         "build-backend": (None, False),
         "commit-file": ("", False),
         "dependencies-file": ("dependencies.yaml", True),

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -1,8 +1,12 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import os
+from typing import TYPE_CHECKING
 
 from .utils import _get_pyproject
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class Config:
@@ -11,7 +15,7 @@ class Config:
     # Mapping from config option to default value (None indicates that option is
     # required) and whether it may be overridden by an environment variable or a config
     # setting.
-    config_options = {
+    config_options: "dict[str, tuple[Any, bool]]" = {
         "build-backend": (None, False),
         "commit-file": ("", False),
         "dependencies-file": ("dependencies.yaml", True),

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -78,7 +78,7 @@ def _get_cuda_version(require_cuda=False):
 
 
 @lru_cache
-def _get_cuda_suffix(require_cuda=False):
+def _get_cuda_suffix(require_cuda=False) -> str:
     """Get the CUDA suffix based on nvcc.
 
     Parameters
@@ -99,7 +99,7 @@ def _get_cuda_suffix(require_cuda=False):
 
 
 @lru_cache
-def _get_git_commit():
+def _get_git_commit() -> str | None:
     """Get the current git commit.
 
     Returns None if git is not in the PATH or if it fails to find the commit.

--- a/rapids_build_backend/utils.py
+++ b/rapids_build_backend/utils.py
@@ -5,7 +5,7 @@ import os
 import tomli
 
 
-def _get_pyproject(dirname="."):
+def _get_pyproject(dirname: str = ".") -> dict:
     """Parse and return the pyproject.toml file."""
     with open(os.path.join(dirname, "pyproject.toml"), "rb") as f:
         return tomli.load(f)


### PR DESCRIPTION
Reading through this project's code for work on https://github.com/rapidsai/build-planning/issues/31, I noticed it isn't using type hints or running a type-checking

This proposes the following:

* adding `mypy` to checks run via pre-commit
* adding type hints for a few cases

I think this'll make the code a little easier to understand, and improve the change of catching some types of bugs (like treating a value which can be `None` as if it was unconditionally not `None) during development.

### How I tested this

```shell
pre-commit run --all-files
```