### PR TITLE
quote configuration options in error messages

### DIFF
--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -63,6 +63,6 @@ class Config:
                 if default_value is not None:
                     return default_value
 
-                raise AttributeError(f"Config is missing required attribute {name}")
+                raise AttributeError(f"Config is missing required attribute '{name}'")
         else:
-            raise AttributeError(f"Attempted to access unknown option {name}")
+            raise AttributeError(f"Attempted to access unknown option '{name}'")


### PR DESCRIPTION
During configuration-processing, there are two places where this project raises errors that include the names of specific config options expected to be found in provided configuration.

At least one of those options is a lowercase word with no other characters, which makes this potential error message a bit confusing:

```text
Config is missing required attribute requires
```

If I saw that in logs and wasn't that familiar with this tool, I might think that's an incomplete sentence and not realize that I need to literally provide a value for an option called `requires`.

This proposes adding single quotes in messages referencing options like that, to hopefully reduce the risk of such confusion. I think this is a little easier to understand:

```text
Config is missing required attribute 'requires'
```

And similarly, if you had a type in config (say `required:` instead of `requires:`):

```text
Attempted to access unknown option 'required'
```