### PR TITLE
Restore support for Python 3.9

### DIFF
--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -12,7 +12,7 @@ jobs:
   check-style:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:cuda12.2.2-ubuntu22.04-py3.9
+      image: rapidsai/ci-conda:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -42,7 +42,7 @@ jobs:
     needs: check-style
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-wheel:cuda12.2.2-ubuntu22.04-py3.9
+      image: rapidsai/ci-wheel:cuda12.2.2-ubuntu20.04-py3.9
     env:
       PUBLISH: "${{ inputs.publish }}"
       RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -24,7 +24,7 @@ jobs:
     needs: check-style
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:cuda12.2.2-ubuntu22.04-py3.9
     env:
       PUBLISH: "${{ inputs.publish }}"
     steps:
@@ -42,7 +42,7 @@ jobs:
     needs: check-style
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-wheel:latest
+      image: rapidsai/ci-wheel:cuda12.2.2-ubuntu22.04-py3.9
     env:
       PUBLISH: "${{ inputs.publish }}"
       RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -12,7 +12,7 @@ jobs:
   check-style:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:cuda12.2.2-ubuntu22.04-py3.9
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from .utils import _get_pyproject
 
@@ -9,13 +9,15 @@ if TYPE_CHECKING:
     from typing import Callable
 
     # config options can be one of these types...
-    config_val_type = str | bool | None
+    config_val_type = Union[str, bool, None]
 
     # ... or a callable that returns one of those or some other mutable types
     mutable_config_val_type = list[str]
-    config_val_callable = Callable[[], config_val_type | mutable_config_val_type]
+    config_val_callable = Callable[[], Union[config_val_type, mutable_config_val_type]]
 
-    config_options_type = dict[str, tuple[config_val_type | config_val_callable, bool]]
+    config_options_type = dict[
+        str, tuple[Union[config_val_type, config_val_callable], bool]
+    ]
 
 
 class Config:

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import os
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from .utils import _get_pyproject
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from typing import Callable, Union
 
     # config options can be one of these types...
     config_val_type = Union[str, bool, None]

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -7,6 +7,7 @@ import subprocess
 from contextlib import contextmanager
 from functools import lru_cache
 from importlib import import_module
+from typing import Union
 
 import rapids_dependency_file_generator
 import tomli_w
@@ -99,7 +100,7 @@ def _get_cuda_suffix(require_cuda=False) -> str:
 
 
 @lru_cache
-def _get_git_commit() -> str | None:
+def _get_git_commit() -> Union[str, None]:
     """Get the current git commit.
 
     Returns None if git is not in the PATH or if it fails to find the commit.


### PR DESCRIPTION
https://github.com/rapidsai/rapids-build-backend/pull/19 added MyPy linting, but CI did not run under Python 3.9, so the new type annotation syntax was used. Use the old syntax to support Python 3.9, and run CI in Python 3.9.