### PR TITLE
Use CI matrix from shared-workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,5 +15,5 @@ jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
-      publish: true
+      build_type: branch
     secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,4 +16,5 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: branch
+      publish: true
     secrets: inherit

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -30,7 +30,7 @@ jobs:
       matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(min_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))])) | [max_by(.PY_VER|split(".")|map(tonumber))]
   build-wheel:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/whels-build.yaml@branch-24.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.06
     with:
       build_type: branch
       script: "ci/build_wheel.sh"

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -40,18 +40,9 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
     with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
       package-name: rapids-build-backend
   publish-conda:
     needs:
       - build-conda
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
   publish-wheels:
     needs:
-      - build-wheels
+      - build-wheel
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
     with:

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -22,7 +22,7 @@ jobs:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.06
     with:
-      build_type: ${{ input.build_type }}
+      build_type: ${{ inputs.build_type }}
       script: "ci/build_python.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
@@ -30,7 +30,7 @@ jobs:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.06
     with:
-      build_type: ${{ input.build_type }}
+      build_type: ${{ inputs.build_type }}
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
@@ -40,7 +40,7 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
     with:
-      build_type: ${{ input.build_type }}
+      build_type: ${{ inputs.build_type }}
       package-name: rapids-build-backend
   publish-conda:
     needs:
@@ -48,4 +48,4 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06
     with:
-      build_type: ${{ input.build_type }}
+      build_type: ${{ inputs.build_type }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -5,6 +5,8 @@ on:
     inputs:
       build_type:
         type: string
+      publish:
+        type: boolean
 
 jobs:
   check-style:
@@ -42,6 +44,7 @@ jobs:
     with:
       build_type: ${{ inputs.build_type }}
       package-name: rapids-build-backend
+    if: ${{ inputs.publish }}
   publish-conda:
     needs:
       - build-conda
@@ -49,3 +52,4 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06
     with:
       build_type: ${{ inputs.build_type }}
+    if: ${{ inputs.publish }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -3,6 +3,8 @@ name: checks
 on:
   workflow_call:
     inputs:
+      publish:
+        type: boolean
 
 jobs:
   check-style:

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -42,9 +42,12 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
     with:
+      build_type: branch
       package-name: rapids-build-backend
   publish-conda:
     needs:
       - build-conda
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06
+    with:
+      build_type: branch

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -3,10 +3,6 @@ name: checks
 on:
   workflow_call:
     inputs:
-      publish:
-        required: false
-        type: string
-        default: "false"
 
 jobs:
   check-style:
@@ -42,7 +38,10 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
     with:
-      build_type: branch
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
       package-name: rapids-build-backend
   publish-conda:
     needs:
@@ -50,4 +49,7 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06
     with:
-      build_type: branch
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -27,7 +27,7 @@ jobs:
       build_type: branch
       script: "ci/build_python.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
-      matrix_filter: [map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]
+      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]'
   build-wheel:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.06
@@ -35,4 +35,4 @@ jobs:
       build_type: branch
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
-      matrix_filter: [map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]
+      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]'

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -36,3 +36,15 @@ jobs:
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
+  publish-wheels:
+    needs:
+      - build-wheels
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
+    with:
+      package-name: rapids-build-backend
+  publish-conda:
+    needs:
+      - build-conda
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -3,8 +3,8 @@ name: checks
 on:
   workflow_call:
     inputs:
-      publish:
-        type: boolean
+      build_type:
+        type: string
 
 jobs:
   check-style:
@@ -22,7 +22,7 @@ jobs:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.06
     with:
-      build_type: branch
+      build_type: ${{ input.build_type }}
       script: "ci/build_python.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
@@ -30,7 +30,7 @@ jobs:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.06
     with:
-      build_type: branch
+      build_type: ${{ input.build_type }}
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
@@ -40,7 +40,7 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
     with:
-      build_type: branch
+      build_type: ${{ input.build_type }}
       package-name: rapids-build-backend
   publish-conda:
     needs:
@@ -48,4 +48,4 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06
     with:
-      build_type: branch
+      build_type: ${{ input.build_type }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -27,7 +27,7 @@ jobs:
       build_type: branch
       script: "ci/build_python.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
-      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]'
+      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
   build-wheel:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.06
@@ -35,4 +35,4 @@ jobs:
       build_type: branch
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
-      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]'
+      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -20,34 +20,19 @@ jobs:
           fetch-depth: 0
       - name: Check style
         run: "./ci/check_style.sh"
-  conda-build:
+  build-conda:
     needs: check-style
-    runs-on: ubuntu-latest
-    container:
-      image: rapidsai/ci-conda:cuda12.2.2-ubuntu22.04-py3.9
-    env:
-      PUBLISH: "${{ inputs.publish }}"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set Proper Conda Upload Token
-        run: |
-          RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
-          if rapids-is-release-build; then
-            RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_TOKEN }}
-          fi
-          echo "RAPIDS_CONDA_TOKEN=${RAPIDS_CONDA_TOKEN}" >> "${GITHUB_ENV}"
-      - name: Python build
-        run: "./ci/build_python.sh ${PUBLISH}"
-  wheel-build:
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-24.06
+    with:
+      build_type: branch
+      script: "ci/build_python.sh"
+      # Select only the build with the minimum Python version and the maximum CUDA version
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(min_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))])) | [max_by(.PY_VER|split(".")|map(tonumber))]
+  build-wheel:
     needs: check-style
-    runs-on: ubuntu-latest
-    container:
-      image: rapidsai/ci-wheel:cuda12.2.2-ubuntu20.04-py3.9
-    env:
-      PUBLISH: "${{ inputs.publish }}"
-      RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
-    steps:
-      - name: checkout code repo
-        uses: actions/checkout@v4
-      - name: Build and repair the wheel
-        run: "./ci/build_wheel.sh ${PUBLISH}"
+    uses: rapidsai/shared-workflows/.github/workflows/whels-build.yaml@branch-24.06
+    with:
+      build_type: branch
+      script: "ci/build_wheel.sh"
+      # Select only the build with the minimum Python version and the maximum CUDA version
+      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(min_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))])) | [max_by(.PY_VER|split(".")|map(tonumber))]

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -27,7 +27,7 @@ jobs:
       build_type: branch
       script: "ci/build_python.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(min_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))])) | [max_by(.PY_VER|split(".")|map(tonumber))]
+      matrix_filter: [map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]
   build-wheel:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-24.06
@@ -35,4 +35,4 @@ jobs:
       build_type: branch
       script: "ci/build_wheel.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
-      matrix_filter: map(select(.ARCH == "amd64")) | group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(min_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))])) | [max_by(.PY_VER|split(".")|map(tonumber))]
+      matrix_filter: [map(select(.ARCH == "amd64")) | min_by((.CUDA_VER | split(".") | map(tonumber) | map(-.)), (.PY_VER | split(".") | map(tonumber)))]

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -40,9 +40,12 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-24.06
     with:
+      build_type: branch
       package-name: rapids-build-backend
   publish-conda:
     needs:
       - build-conda
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-24.06
+    with:
+      build_type: branch

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,4 +14,5 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: pull-request
+      publish: false
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,5 +13,5 @@ jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
-      publish: false
+      build_type: pull-request
     secrets: inherit

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -3,7 +3,5 @@
 
 set -euo pipefail
 
-UPLOAD_PACKAGES="${1:-false}"
-
 PKG_DIR="${PWD}/conda_package"
 rapids-conda-retry mambabuild --output-folder "${PKG_DIR}" conda/recipes/rapids-build-backend

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -3,5 +3,6 @@
 
 set -euo pipefail
 
-PKG_DIR="${PWD}/conda_package"
-rapids-conda-retry mambabuild --output-folder "${PKG_DIR}" conda/recipes/rapids-build-backend
+rapids-conda-retry mambabuild conda/recipes/rapids-build-backend
+
+rapids-upload-conda-to-s3 python

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -7,8 +7,3 @@ UPLOAD_PACKAGES="${1:-false}"
 
 PKG_DIR="${PWD}/conda_package"
 rapids-conda-retry mambabuild --output-folder "${PKG_DIR}" conda/recipes/rapids-build-backend
-
-if [ "$UPLOAD_PACKAGES" = "true" ]; then
-    # TODO: Figure out the best way to get CONDA_PKG_FILE
-    rapids-retry anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --label main --skip-existing --no-progress "${PKG_DIR}/noarch/"*.tar.bz2
-fi

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,3 +9,5 @@ python -m pip wheel . -w dist -vv --no-deps --disable-pip-version-check
 WHL_FILE=$(ls dist/*.whl)
 python -m pip install "${WHL_FILE}[test]"
 python -m pytest -v tests/
+
+rapids-upload-wheels-to-s3 dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,15 +3,9 @@
 
 set -euo pipefail
 
-UPLOAD_PACKAGES="${1:-false}"
-
 python -m pip wheel . -w dist -vv --no-deps --disable-pip-version-check
 
 # Run tests
 WHL_FILE=$(ls dist/*.whl)
 python -m pip install "${WHL_FILE}[test]"
 python -m pytest -v tests/
-
-if [ "$UPLOAD_PACKAGES" = "true" ]; then
-    anaconda -t "${RAPIDS_CONDA_TOKEN}" upload --skip-existing --no-progress ${WHL_FILE}
-fi


### PR DESCRIPTION
#21 restored Python 3.9 support, but used hard-coded CI images. Use https://github.com/rapidsai/shared-workflows to select an appropriate CI image.