### PR TITLE
remove require_cuda defaults in internal functions

### DIFF
--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -39,7 +39,7 @@ def _get_backend(build_backend):
 
 
 @lru_cache
-def _get_cuda_version(require_cuda=False):
+def _get_cuda_version(require_cuda: bool):
     """Get the CUDA suffix based on nvcc.
 
     Parameters
@@ -79,7 +79,7 @@ def _get_cuda_version(require_cuda=False):
 
 
 @lru_cache
-def _get_cuda_suffix(require_cuda=False) -> str:
+def _get_cuda_suffix(require_cuda: bool) -> str:
     """Get the CUDA suffix based on nvcc.
 
     Parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,10 @@ def patch_nvcc_if_needed(nvcc_version):
     try:
         # Only create a patch if one is required. In addition to reducing overhead, this
         # also ensures that we test the real nvcc and don't mask any relevant errors.
-        if _get_cuda_version() is None or _get_cuda_version()[0] != nvcc_version:
+        if (
+            _get_cuda_version(False) is None
+            or _get_cuda_version(False)[0] != nvcc_version
+        ):
             nvcc = _create_nvcc(nvcc_version)
             os.environ["PATH"] = os.pathsep.join(
                 [os.path.dirname(nvcc), os.environ["PATH"]]


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31.

This project attempts to determine the version of CUDA present on the system using `nvcc`. By default, if that attempt fails it raises an exception.

This is configurable from the public API of the build backend, like this in `pyproject.toml`...

```toml
[tool.rapids-build-backend]
require-cuda = true
```

https://github.com/rapidsai/rapids-build-backend/blob/0c7e6d1e937c21a871a6ed70df423942b3694d57/README.md#L25

This PR proposes removing defaults in the signatures of internal functions that perform implement that behavior, to reduce the risk of *"oops forgot to pass this through and `rapids-build-backend` silently fell back to some a default"* types of bugs.

In my opinion, it'd be useful to restrict knowledge of default values for configuration to exactly one place... the code used to parse configuration.

https://github.com/rapidsai/rapids-build-backend/blob/0c7e6d1e937c21a871a6ed70df423942b3694d57/rapids_build_backend/config.py#L26-L37

And in general, for there to be as few competing sources of configuration values as possible.

### How I tested this

Looked for all uses like this.

```shell
_get_cuda
```

Otherwise, relying on this project's `pre-commit` + CI.