### PR TITLE
Fix upload step

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  push:
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  run-checks:
+    uses: ./.github/workflows/checks-and-builds.yaml
+    with:
+      build_type: branch
+      publish: false
+    secrets: inherit

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -2,8 +2,6 @@ name: build
 
 on:
   push:
-    branches:
-      - "main"
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,5 +14,5 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: pull-request
-      publish: false
+      publish: true
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,5 +14,5 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: pull-request
-      publish: true
+      publish: false
     secrets: inherit

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -10,4 +10,4 @@ WHL_FILE=$(ls dist/*.whl)
 python -m pip install "${WHL_FILE}[test]"
 python -m pytest -v tests/
 
-rapids-upload-wheels-to-s3 dist
+RAPIDS_PY_WHEEL_NAME="rapids-build-backend" rapids-upload-wheels-to-s3 dist


### PR DESCRIPTION
https://github.com/rapidsai/rapids-build-backend/pull/22 changed how the package is uploaded to S3, but did not include `RAPIDS_PY_WHEEL_NAME`. Fix uploading, and also don't publish the `main` branch.