### PR TITLE
remove 'disable-cuda-suffix' config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It currently support `scikit-build-core` and `setuptools` as the wrapped builder
 The package's primary purpose is to automate the various bits of preprocessing that are typically done to RAPIDS package metadata prior to publishing packages.
 This includes the following notable changes:
 - Running [`rapids-dependency-file-generator`](https://github.com/rapidsai/dependency-file-generator) to get the dependencies for the CUDA version and architecture.
-- Modifying the package name to include CUDA suffixes.
+- Modifying the package name to include a CUDA suffix (e.g. `"rmm" -> "rmm-cu11"`)
 - Updating the git commit embedded in the importable package.
 
 Since some of these modifications are only desirable in certain scenarios (wheel vs conda builds vs editable installs), all of these functions are customizable via the project's configuration in pyproject.toml.
@@ -20,7 +20,6 @@ Any option without a default is required.
 | `build-backend`       | The wrapped build backend (e.g. `setuptools.build_meta`)            | string         |                     | N                             |
 | `commit-file`         | The file in which to write the git commit hash                      | string         | "" (No file)        | N                             |
 | `dependencies-file`   | The path to the `dependencies.yaml` file to use                     | string         | "dependencies.yaml" | Y                             |
-| `disable-cuda-suffix` | If true, don't try to write CUDA suffixes                           | bool           | false               | Y                             |
 | `matrix-entry`        | A `;`-separated list of `=`-delimited key/value pairs               | string         | ""                  | Y                             |
 | `require-cuda`        | If false, builds will succeed even if nvcc is not available         | bool           | true                | Y                             |
 | `requires`            | List of build requirements (in addition to `build-system.requires`) | list[str]      | []                  | N                             |

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -30,7 +30,6 @@ class Config:
         "build-backend": (None, False),
         "commit-file": ("", False),
         "dependencies-file": ("dependencies.yaml", True),
-        "disable-cuda-suffix": (False, True),
         "matrix-entry": ("", True),
         "require-cuda": (True, True),
         "requires": (lambda: [], False),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,9 +27,6 @@ def setup_config_project(tmp_path, flag, config_value):
     [
         ("commit-file", '"pkg/_version.py"', "pkg/_version.py"),
         ("commit-file", None, ""),
-        ("disable-cuda-suffix", "true", True),
-        ("disable-cuda-suffix", "false", False),
-        ("disable-cuda-suffix", None, False),
         ("require-cuda", "true", True),
         ("require-cuda", "false", False),
         ("require-cuda", None, True),
@@ -43,8 +40,6 @@ def test_config(tmp_path, flag, config_value, expected):
 @pytest.mark.parametrize(
     "flag, config_value, expected",
     [
-        ("disable-cuda-suffix", "true", True),
-        ("disable-cuda-suffix", "false", False),
         ("require-cuda", "true", True),
         ("require-cuda", "false", False),
     ],
@@ -68,8 +63,6 @@ def test_config_env_var(tmp_path, flag, config_value, expected):
 @pytest.mark.parametrize(
     "flag, config_value, expected",
     [
-        ("disable-cuda-suffix", "true", True),
-        ("disable-cuda-suffix", "false", False),
         ("require-cuda", "true", True),
         ("require-cuda", "false", False),
     ],


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31

Proposes removing config setting `disable-cuda-suffix`. As of this writing, it doesn't affect the behavior of `rapids-build-backend`.

We talked offline about this and agreed to remove it for now to simplify the interface and only add it back in the future when a specific use case requires it.