### PR TITLE
Prefix and filter command line options with `rapidsai.`

### DIFF
--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -68,10 +68,14 @@ class Config:
                         return str_val == "true"
                     return os.environ[env_var]
 
-                if config_name in self.config_settings:
+                try:
+                    value = self.config_settings[f"rapidsai.{config_name}"]
+                except KeyError:
+                    pass
+                else:
                     if isinstance(default_value, bool):
-                        return self.config_settings[config_name] == "true"
-                    return self.config_settings[config_name]
+                        return value == "true"
+                    return value
 
             try:
                 return self.config[config_name]

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -68,14 +68,11 @@ class Config:
                         return str_val == "true"
                     return os.environ[env_var]
 
-                try:
-                    value = self.config_settings[f"rapidsai.{config_name}"]
-                except KeyError:
-                    pass
-                else:
+                config_key = f"rapidsai.{config_name}"
+                if config_key in self.config_settings:
                     if isinstance(default_value, bool):
-                        return value == "true"
-                    return value
+                        return self.config_settings[config_key] == "true"
+                    return self.config_settings[config_key]
 
             try:
                 return self.config[config_name]

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -68,8 +68,7 @@ class Config:
                         return str_val == "true"
                     return os.environ[env_var]
 
-                config_key = f"rapidsai.{config_name}"
-                if config_key in self.config_settings:
+                if (config_key := f"rapidsai.{config_name}") in self.config_settings:
                     if isinstance(default_value, bool):
                         return self.config_settings[config_key] == "true"
                     return self.config_settings[config_key]

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -17,6 +17,12 @@ from . import utils
 from .config import Config
 
 
+def _remove_rapidsai_from_config(config_settings):
+    if not config_settings:
+        return None
+    return {k: v for k, v in config_settings.items() if not k.startswith("rapidsai.")}
+
+
 def _parse_matrix(matrix):
     if not matrix:
         return None
@@ -222,7 +228,11 @@ def get_requires_for_build_wheel(config_settings):
             backend := _get_backend(config.build_backend),
             "get_requires_for_build_wheel",
         ):
-            requires.extend(backend.get_requires_for_build_wheel(config_settings))
+            requires.extend(
+                backend.get_requires_for_build_wheel(
+                    _remove_rapidsai_from_config(config_settings)
+                )
+            )
 
         return requires
 
@@ -240,7 +250,11 @@ def get_requires_for_build_sdist(config_settings):
             backend := _get_backend(config.build_backend),
             "get_requires_for_build_sdist",
         ):
-            requires.extend(backend.get_requires_for_build_sdist(config_settings))
+            requires.extend(
+                backend.get_requires_for_build_sdist(
+                    _remove_rapidsai_from_config(config_settings)
+                )
+            )
 
         return requires
 
@@ -256,7 +270,11 @@ def get_requires_for_build_editable(config_settings):
             backend := _get_backend(config.build_backend),
             "get_requires_for_build_editable",
         ):
-            requires.extend(backend.get_requires_for_build_editable(config_settings))
+            requires.extend(
+                backend.get_requires_for_build_editable(
+                    _remove_rapidsai_from_config(config_settings)
+                )
+            )
 
         return requires
 
@@ -267,7 +285,9 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     project_name = pyproject["project"]["name"]
     with _edit_pyproject(config), _write_git_commits(config, project_name):
         return _get_backend(config.build_backend).build_wheel(
-            wheel_directory, config_settings, metadata_directory
+            wheel_directory,
+            _remove_rapidsai_from_config(config_settings),
+            metadata_directory,
         )
 
 
@@ -277,7 +297,7 @@ def build_sdist(sdist_directory, config_settings=None):
     project_name = pyproject["project"]["name"]
     with _edit_pyproject(config), _write_git_commits(config, project_name):
         return _get_backend(config.build_backend).build_sdist(
-            sdist_directory, config_settings
+            sdist_directory, _remove_rapidsai_from_config(config_settings)
         )
 
 
@@ -285,7 +305,9 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     config = Config(config_settings=config_settings)
     with _edit_pyproject(config):
         return _get_backend(config.build_backend).build_editable(
-            wheel_directory, config_settings, metadata_directory
+            wheel_directory,
+            _remove_rapidsai_from_config(config_settings),
+            metadata_directory,
         )
 
 
@@ -293,7 +315,7 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     config = Config(config_settings=config_settings)
     with _edit_pyproject(config):
         return _get_backend(config.build_backend).prepare_metadata_for_build_wheel(
-            metadata_directory, config_settings
+            metadata_directory, _remove_rapidsai_from_config(config_settings)
         )
 
 
@@ -301,5 +323,5 @@ def prepare_metadata_for_build_editable(metadata_directory, config_settings=None
     config = Config(config_settings=config_settings)
     with _edit_pyproject(config):
         return _get_backend(config.build_backend).prepare_metadata_for_build_editable(
-            metadata_directory, config_settings
+            metadata_directory, _remove_rapidsai_from_config(config_settings)
         )

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -20,10 +20,9 @@ from .config import Config
 def _remove_rapidsai_from_config(
     config_settings: typing.Union[dict[str, typing.Any], None],
 ) -> typing.Union[dict[str, typing.Any], None]:
-    """
-    Filter out settings that begin with `rapidsai.` to be passed down to the underlying
-    backend, because some backends get confused if you pass them options that they don't
-    recognize.
+    """Filter out settings that begin with ``rapidsai.`` to be passed down to the
+    underlying backend, because some backends get confused if you pass them options that
+    they don't recognize.
     """
     if not config_settings:
         return None

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -4,11 +4,11 @@ import os
 import re
 import shutil
 import subprocess
+import typing
 import warnings
 from contextlib import contextmanager
 from functools import lru_cache
 from importlib import import_module
-from typing import Union
 
 import rapids_dependency_file_generator
 import tomlkit
@@ -17,7 +17,14 @@ from . import utils
 from .config import Config
 
 
-def _remove_rapidsai_from_config(config_settings):
+def _remove_rapidsai_from_config(
+    config_settings: typing.Union[dict[str, typing.Any], None],
+) -> typing.Union[dict[str, typing.Any], None]:
+    """
+    Filter out settings that begin with `rapidsai.` to be passed down to the underlying
+    backend, because some backends get confused if you pass them options that they don't
+    recognize.
+    """
     if not config_settings:
         return None
     return {k: v for k, v in config_settings.items() if not k.startswith("rapidsai.")}
@@ -89,7 +96,7 @@ def _get_cuda_suffix() -> str:
 
 
 @lru_cache
-def _get_git_commit() -> Union[str, None]:
+def _get_git_commit() -> typing.Union[str, None]:
     """Get the current git commit.
 
     Returns None if git is not in the PATH or if it fails to find the commit.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,6 +71,6 @@ def test_config_env_var(tmp_path, flag, config_value, expected):
 def test_config_config_settings(tmp_path, flag, config_value, expected):
     config = Config(
         setup_config_project(tmp_path, flag, None),
-        {flag: config_value},
+        {f"rapidsai.{flag}": config_value},
     )
     assert getattr(config, flag.replace("-", "_")) == expected

--- a/tests/test_impls.py
+++ b/tests/test_impls.py
@@ -10,6 +10,7 @@ import pytest
 from rapids_build_backend.impls import (
     _edit_pyproject,
     _get_cuda_suffix,
+    _remove_rapidsai_from_config,
     _write_git_commits,
 )
 
@@ -22,6 +23,12 @@ def set_cwd(cwd):
         yield
     finally:
         os.chdir(old_cwd)
+
+
+def test_remove_rapidsai_from_config():
+    assert _remove_rapidsai_from_config(
+        {"rapidsai.disable-cuda": "true", "skbuild.build-dir": "build"}
+    ) == {"skbuild.build-dir": "build"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Some build backends, like `scikit-build-core`, get confused if you pass them options that they don't recognize. Filter out RAPIDS' config options from getting to the build backend, and prefix them with `rapidsai.` to make the filtering easier.