### PR TITLE
Version 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 
 [project]
 name = "rapids-build-backend"
-version = "0.3.0"
+version = "0.3.1"
 description = "Custom PEP517 builder for RAPIDS"
 dependencies = [
     "PyYAML",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/31

Proposes releasing #41 as v0.3.1.

Yes #41 was "breaking", but not in any practical way... no project currently using `rapids-build-backend` should observe any change in behavior as a result of merging that.

So this proposes `0.3.0 -> 0.3.1`, so that the new package will still get pulled in in builds of all the projects already using constraints like `rapids-build-backend>=0.3.0,<0.4.0dev0`