### PR TITLE
Version 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 
 [project]
 name = "rapids-build-backend"
-version = "0.3.1"
+version = "0.3.2"
 description = "Custom PEP517 builder for RAPIDS"
 dependencies = [
     "PyYAML",


### PR DESCRIPTION
Fixes https://github.com/rapidsai/rapids-build-backend/issues/48

Try a new release to see if publishing to `rapidsai` now works