### PR TITLE
Add rapids-test-dummy package for testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,8 +164,8 @@ def wheelhouse(tmp_path_factory, pip_cache):
     """A PEP 517 wheelhouse containing the local copy of rapids-build-backend."""
     wheelhouse = tmp_path_factory.mktemp("wheelhouse")
 
-    # Build the rapids-builder wheel in a temporary directory where we can bump the
-    # version to ensure that it is preferred to any other available wheels.
+    # Build the rapids-build-backend wheel in a temporary directory where we can bump
+    # the version to ensure that it is preferred to any other available wheels.
     rapids_build_backend_build_dir = tmp_path_factory.mktemp(
         "rapids_build_backend_build_dir"
     )
@@ -174,11 +174,6 @@ def wheelhouse(tmp_path_factory, pip_cache):
         DIR,
         rapids_build_backend_build_dir,
         ignore=shutil.ignore_patterns("tests*"),
-        dirs_exist_ok=True,
-    )
-    shutil.copytree(
-        DIR / "tests/rapids-test-dummy",
-        rapids_build_backend_build_dir / "tests/rapids-test-dummy",
         dirs_exist_ok=True,
     )
 
@@ -219,7 +214,7 @@ def wheelhouse(tmp_path_factory, pip_cache):
             str(wheelhouse),
             "--cache-dir",
             pip_cache,
-            f"{rapids_build_backend_build_dir}/tests/rapids-test-dummy",
+            f"{DIR}/tests/rapids-test-dummy",
         ],
         check=True,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,11 @@ def wheelhouse(tmp_path_factory, pip_cache):
         ignore=shutil.ignore_patterns("tests*"),
         dirs_exist_ok=True,
     )
+    shutil.copytree(
+        DIR / "tests/rapids-test-dummy",
+        rapids_build_backend_build_dir / "tests/rapids-test-dummy",
+        dirs_exist_ok=True,
+    )
 
     pyproject_file = rapids_build_backend_build_dir / "pyproject.toml"
     with open(pyproject_file) as f:
@@ -199,6 +204,22 @@ def wheelhouse(tmp_path_factory, pip_cache):
             "--cache-dir",
             pip_cache,
             f"{rapids_build_backend_build_dir}",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--disable-pip-version-check",
+            "--wheel-dir",
+            str(wheelhouse),
+            "--cache-dir",
+            pip_cache,
+            f"{rapids_build_backend_build_dir}/tests/rapids-test-dummy",
         ],
         check=True,
     )

--- a/tests/rapids-test-dummy/pyproject.toml
+++ b/tests/rapids-test-dummy/pyproject.toml
@@ -1,0 +1,5 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+[project]
+name = "rapids-test-dummy"
+version = "0.0.1"

--- a/tests/rapids-test-dummy/rapids_test_dummy/__init__.py
+++ b/tests/rapids-test-dummy/rapids_test_dummy/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+__version__ = "0.0.1"

--- a/tests/templates/dependencies-rbb-only.yaml
+++ b/tests/templates/dependencies-rbb-only.yaml
@@ -24,7 +24,7 @@ dependencies:
         matrices:
           - matrix: {cuda: "85.*"}
             packages:
-              - more-itertools
+              - rapids-test-dummy
           # keeping this empty means it'll only be filled in if
           # rapids-build-backend actually resolves one of the CUDA-specific
           # matrices


### PR DESCRIPTION
Tests previously relied on the more-itertools package, but that package is now a dependency of one of rapids-build-backend's dependencies. Create a new rapids-test-dummy package to ensure that there's no way it could accidentally be installed transitively.