### PR TITLE
update pre-commit hook versions, use new ruff config format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.13.11
+    rev: v1.14.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean"]
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.6.4
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -32,7 +32,7 @@ repos:
       - id: verify-copyright
         args: [--fix, --main-branch=main]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.10.0'
+    rev: 'v1.11.2'
     hooks:
       - id: mypy
         args: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,19 @@ include = ["rapids_build_backend*"]
 [tool.mypy]
 ignore_missing_imports = true
 
-[tool.ruff]
-lint.select = ["E", "F", "W", "I", "N", "UP"]
-lint.fixable = ["ALL"]
+[tool.ruff.lint]
+select = [
+    # pycodestyle (errors)
+    "E",
+    # isort
+    "I",
+    # pyflakes
+    "F",
+    # pep8-naming
+    "N",
+    # pyupgrade
+    "UP",
+    # pycodestyle (warnings)
+    "W",
+]
+fixable = ["ALL"]


### PR DESCRIPTION
At least a year ago (I'm not sure when precisely), `ruff` broke up the `[ruff]` table in `pyproject.toml` in favor of storing configuration in several more focused tables, like `[tool.ruff.lint]`. Context: https://github.com/rapidsai/rapids-reviser/pull/51/files#r1755430166

This proposes the following:

* using that new format here, to avoid build issues when that deprecation eventually is enforced and becomes an error
* updating all the pre-commit hooks w/ `pre-commit autoupdate`