### PR TITLE
Pass current machine's architecture to rapids-dependency-file-generator.

### DIFF
--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -53,7 +53,7 @@ def _get_backend(build_backend):
 
 
 @lru_cache
-def _get_arch():
+def _get_arch() -> str:
     """Get the arch of the current machine.
 
     Returns
@@ -61,7 +61,12 @@ def _get_arch():
     str
         The arch (e.g. "x86_64" or "aarch64")
     """
-    return platform.machine()
+    plat = platform.machine()
+    # RAPIDS projects all use "aarch64" to indicate arm architectures,
+    # but arm some systems (like the M1/M2/M3 Macs) report "arm64"
+    if plat == "arm64":
+        return "aarch64"
+    return plat
 
 
 @lru_cache

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -49,6 +50,18 @@ def _get_backend(build_backend):
             "optional dependency in your build-system.requires entry for "
             "rapids-build-backend."
         )
+
+
+@lru_cache
+def _get_arch():
+    """Get the arch of the current machine.
+
+    Returns
+    -------
+    str
+        The arch (e.g. "x86_64" or "aarch64")
+    """
+    return platform.machine()
 
 
 @lru_cache
@@ -190,6 +203,7 @@ def _edit_pyproject(config):
                 matrix = _parse_matrix(config.matrix_entry) or dict(file_config.matrix)
                 if not config.disable_cuda:
                     matrix["cuda"] = [f"{cuda_version_major}.{cuda_version_minor}"]
+                matrix["arch"] = [_get_arch()]
                 rapids_dependency_file_generator.make_dependency_files(
                     parsed_config=parsed_config,
                     file_keys=[file_key],


### PR DESCRIPTION
This PR passes the current machine architecture to rapids-dependency-file-generator. This makes it possible to use arch-specific matrices in pyproject outputs.
