### PR TITLE
Enable publishes to nightly anaconda on pushes to main

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -14,5 +14,5 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: branch
-      publish: false
+      publish: true
     secrets: inherit


### PR DESCRIPTION
The workflow setup currently does not publish to https://anaconda.org/rapidsai-nightly and only publishes to https://anaconda.org/rapidsai (via tags); this introduces an issue where conda solves which use the `rapisai-nightly` channel fails.

So this PR updates the setup to publish to `rapidsai-nightly` on pushes to main.