### PR TITLE
remove conda-verify dependency

### DIFF
--- a/conda/recipes/rapids-build-backend/meta.yaml
+++ b/conda/recipes/rapids-build-backend/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 {% set pyproject_data = load_file_data("pyproject.toml") %}
 {% set version = pyproject_data["project"]["version"] %}
@@ -19,7 +19,6 @@ requirements:
   host:
     - pip
     - python >=3.9
-    - conda-verify
     {% for r in pyproject_data["build-system"]["requires"] %}
     - {{ r }}
     {% endfor %}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/150

Proposes removing `host:` dependency on `conda-verify`. See the discussion in https://github.com/rapidsai/rapids-metadata/issues/43 for background.