### PR TITLE
Replace `conda-mambabuild`with `conda-build`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -3,6 +3,6 @@
 
 set -euo pipefail
 
-rapids-conda-retry mambabuild conda/recipes/rapids-build-backend
+rapids-conda-retry build conda/recipes/rapids-build-backend
 
 rapids-upload-conda-to-s3 python


### PR DESCRIPTION
These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149