### PR TITLE
override workflow name in package-uploading workflows

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -14,5 +14,8 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: branch
+      # RAPIDS tooling assumes that builds for 'build_type=branch' come from a file 'build.yaml'.
+      # This adjusts that expectation to match the way this repo works.
+      build_workflow_name: "build-main.yaml"
       publish: true
     secrets: inherit

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -14,5 +14,8 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: branch
+      # RAPIDS tooling assumes that builds for 'build_type=branch' come from a file 'build.yaml'.
+      # This adjusts that expectation to match the way this repo works.
+      build_workflow_name: "build-tag.yaml"
       publish: true
     secrets: inherit

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -5,6 +5,12 @@ on:
     inputs:
       build_type:
         type: string
+      build_workflow_name:
+        description: |
+          Name of a workflow file that produced artifacts to be downloaded in this run.
+          If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
+        required: true
+        type: string
       publish:
         type: boolean
 
@@ -46,6 +52,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.10
     with:
       build_type: ${{ inputs.build_type }}
+      build_workflow_name: ${{ inputs.build_workflow_name }}
       package-name: rapids-build-backend
       publish_to_pypi: true
     if: ${{ inputs.publish }}
@@ -56,4 +63,5 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.10
     with:
       build_type: ${{ inputs.build_type }}
+      build_workflow_name: ${{ inputs.build_workflow_name }}
     if: ${{ inputs.publish }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -28,7 +28,7 @@ jobs:
         run: "./ci/check_style.sh"
   build-conda:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@build-workflow-name
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.10
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_python.sh"
@@ -36,7 +36,7 @@ jobs:
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
   build-wheel:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@build-workflow-name
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.10
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_wheel.sh"
@@ -49,7 +49,7 @@ jobs:
     needs:
       - build-wheel
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@build-workflow-name
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.10
     with:
       build_type: ${{ inputs.build_type }}
       build_workflow_name: ${{ inputs.build_workflow_name }}
@@ -60,7 +60,7 @@ jobs:
     needs:
       - build-conda
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@build-workflow-name
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.10
     with:
       build_type: ${{ inputs.build_type }}
       build_workflow_name: ${{ inputs.build_workflow_name }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -28,7 +28,7 @@ jobs:
         run: "./ci/check_style.sh"
   build-conda:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@build-workflow-name
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_python.sh"
@@ -36,7 +36,7 @@ jobs:
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
   build-wheel:
     needs: check-style
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@build-workflow-name
     with:
       build_type: ${{ inputs.build_type }}
       script: "ci/build_wheel.sh"
@@ -49,7 +49,7 @@ jobs:
     needs:
       - build-wheel
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@build-workflow-name
     with:
       build_type: ${{ inputs.build_type }}
       build_workflow_name: ${{ inputs.build_workflow_name }}
@@ -60,7 +60,7 @@ jobs:
     needs:
       - build-conda
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@build-workflow-name
     with:
       build_type: ${{ inputs.build_type }}
       build_workflow_name: ${{ inputs.build_workflow_name }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,5 +14,9 @@ jobs:
     uses: ./.github/workflows/checks-and-builds.yaml
     with:
       build_type: pull-request
+      # RAPIDS tooling assumes that builds for 'build_type=branch' come from a file 'build.yaml'.
+      # checks-and-builds.yaml provides an input so other workflows in this repo can override that, to match this repo's setup.
+      # That input is required, so passing 'pr.yaml' here.
+      build_workflow_name: "pr.yaml"
       publish: false
     secrets: inherit

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+echo "---printing env---"
+env
+
 python -m pip wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -vv --no-deps --disable-pip-version-check
 
 # Run tests

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-echo "---printing env---"
-env
-
 python -m pip wheel . -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" -vv --no-deps --disable-pip-version-check
 
 # Run tests


### PR DESCRIPTION
Attempts to publish v0.4.0 are failing like this:

> HTTP 404: workflow build.yaml not found on the default branch (https://api.github.com/repos/rapidsai/rapids-build-backend/actions/workflows/build.yaml)

([build link](https://github.com/rapidsai/rapids-build-backend/actions/runs/16676292209/job/47203928533))

Because the relevant RAPIDS tools expect that builds with `build_type="branch"` produce artifacts from a workflow named `build.yaml`, and this repo does not.

This fixes that by informing that tooling of the workflows used in this project.

See https://github.com/rapidsai/shared-workflows/pull/406 for more details.

## Notes for Reviewers

### How I tested this

Saw PR CI succeed on using the branch from that `shared-workflows` PR:

* https://github.com/rapidsai/rapids-build-backend/pull/71/commits/83e9d2211553f96e8dbd06188f3add9b609fb390
* https://github.com/rapidsai/rapids-build-backend/actions/runs/16677534472/job/47207877751?pr=71

Saw a `branch` CI run for `rmm` succeed with this new workflow: (TBD)

