### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,14 +1,12 @@
 name: build
-
 on:
   push:
     branches:
       - "main"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -18,4 +18,8 @@ jobs:
       # This adjusts that expectation to match the way this repo works.
       build_workflow_name: "build-main.yaml"
       publish: true
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -1,14 +1,12 @@
 name: build
-
 on:
   push:
     tags:
       - "v*.*.*"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -18,4 +18,8 @@ jobs:
       # This adjusts that expectation to match the way this repo works.
       build_workflow_name: "build-tag.yaml"
       publish: true
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -1,5 +1,4 @@
 name: checks
-
 on:
   workflow_call:
     inputs:
@@ -13,7 +12,16 @@ on:
         type: string
       publish:
         type: boolean
-
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN:
+        required: true
+      RAPIDSAI_PYPI_TOKEN:
+        required: true
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN:
+        required: true
+      CONDA_RAPIDSAI_TOKEN:
+        required: true
+permissions: {}
 jobs:
   check-style:
     runs-on: ubuntu-latest
@@ -48,7 +56,9 @@ jobs:
   publish-wheels:
     needs:
       - build-wheel
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@main
     with:
       build_type: ${{ inputs.build_type }}
@@ -59,7 +69,9 @@ jobs:
   publish-conda:
     needs:
       - build-conda
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
     uses: rapidsai/shared-workflows/.github/workflows/conda-upload-packages.yaml@main
     with:
       build_type: ${{ inputs.build_type }}

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -42,6 +42,12 @@ jobs:
       script: "ci/build_python.sh"
       # Select only the build with the minimum Python version and the maximum CUDA version
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   build-wheel:
     needs: check-style
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
@@ -53,6 +59,12 @@ jobs:
       package-name: rapids-build-backend
       package-type: python
       append-cuda-suffix: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   publish-wheels:
     needs:
       - build-wheel
@@ -66,6 +78,12 @@ jobs:
       package-name: rapids-build-backend
       publish_to_pypi: true
     if: ${{ inputs.publish }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   publish-conda:
     needs:
       - build-conda
@@ -77,3 +95,9 @@ jobs:
       build_type: ${{ inputs.build_type }}
       build_workflow_name: ${{ inputs.build_workflow_name }}
     if: ${{ inputs.publish }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -26,12 +26,13 @@ jobs:
   check-style:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:latest # zizmor: ignore[unpinned-images]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check style
         run: "./ci/check_style.sh"
   build-conda:

--- a/.github/workflows/checks-and-builds.yaml
+++ b/.github/workflows/checks-and-builds.yaml
@@ -29,7 +29,7 @@ jobs:
       image: rapidsai/ci-conda:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Check style

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,14 +1,12 @@
 name: pr
-
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,4 +19,8 @@ jobs:
       # That input is required, so passing 'pr.yaml' here.
       build_workflow_name: "pr.yaml"
       publish: false
-    secrets: inherit
+    secrets:
+      CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+      RAPIDSAI_PYPI_TOKEN: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+      CONDA_RAPIDSAI_NIGHTLY_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
+      CONDA_RAPIDSAI_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,10 @@ repos:
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
 
 default_language_version:
       python: python3


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275