### PR TITLE
fix CI permissions, drop Python 3.9

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -10,6 +10,12 @@ permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     with:
       build_type: branch
       # RAPIDS tooling assumes that builds for 'build_type=branch' come from a file 'build.yaml'.

--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -10,6 +10,12 @@ permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     with:
       build_type: branch
       # RAPIDS tooling assumes that builds for 'build_type=branch' come from a file 'build.yaml'.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,12 @@ permissions: {}
 jobs:
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
     with:
       build_type: pull-request
       # RAPIDS tooling assumes that builds for 'build_type=branch' come from a file 'build.yaml'.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,6 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
-        additional_dependencies:
-          - identify>=2.6.13
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v1.4.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,27 +8,27 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.20.0
+    rev: v1.20.3
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean", "--warn-all", "--strict"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.2
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.15.15
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.3.3
+    rev: v1.4.3
     hooks:
       - id: verify-copyright
         args: [--fix, --spdx]
@@ -48,7 +48,7 @@ repos:
           (?x)
             ^tests/.*$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.11.2'
+    rev: 'v2.1.0'
     hooks:
       - id: mypy
         args: [
@@ -57,12 +57,12 @@ repos:
         ]
         pass_filenames: false
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.2
     hooks:
       - id: zizmor
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,8 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+        additional_dependencies:
+          - identify>=2.6.13
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v1.4.3

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For example:
 [build-system]
 build-backend = "rapids_build_backend.build"
 requires = [
-    "rapids-build-backend>=0.3.0,<0.4.0dev0",
+    "rapids-build-backend>=0.3.0,<0.5.0dev0",
     "setuptools>=64.0.0",
 ]
 ```

--- a/conda/recipes/rapids-build-backend/meta.yaml
+++ b/conda/recipes/rapids-build-backend/meta.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 {% set pyproject_data = load_file_data("pyproject.toml") %}
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.9
+    - python >=3.10
     {% for r in pyproject_data["build-system"]["requires"] %}
     - {{ r }}
     {% endfor %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator
@@ -53,15 +53,12 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
+          - identify>=2.6.13
           - pre-commit
   py_version:
     specific:
       - output_types: conda
         matrices:
-          - matrix:
-              py: "3.9"
-            packages:
-              - python=3.9
           - matrix:
               py: "3.10"
             packages:
@@ -72,7 +69,7 @@ dependencies:
               - python=3.11
           - matrix:
             packages:
-              - python>=3.9,<3.12
+              - python>=3.10,<3.12
   run:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires = [
 name = "rapids-build-backend"
 version = "0.4.1"
 description = "Custom PEP517 builder for RAPIDS"
+requires-python = ">=3.10"
 dependencies = [
     "PyYAML",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 
 [project]
 name = "rapids-build-backend"
-version = "0.4.1"
+version = "0.4.2"
 description = "Custom PEP517 builder for RAPIDS"
 requires-python = ">=3.10"
 dependencies = [

--- a/rapids_build_backend/config.py
+++ b/rapids_build_backend/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -7,17 +7,17 @@ from typing import TYPE_CHECKING
 from .utils import _get_pyproject
 
 if TYPE_CHECKING:
-    from typing import Callable, Union
+    from collections.abc import Callable
 
     # config options can be one of these types...
-    config_val_type = Union[str, bool, None]
+    config_val_type = str | bool | None
 
     # ... or a callable that returns one of those or some other mutable types
     mutable_config_val_type = list[str]
-    config_val_callable = Callable[[], Union[config_val_type, mutable_config_val_type]]
+    config_val_callable = Callable[[], config_val_type | mutable_config_val_type]
 
     config_options_type = dict[
-        str, tuple[Union[config_val_type, config_val_callable], bool, bool]
+        str, tuple[config_val_type | config_val_callable, bool, bool]
     ]
 
 

--- a/rapids_build_backend/impls.py
+++ b/rapids_build_backend/impls.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -20,8 +20,8 @@ from .config import Config
 
 
 def _remove_rapidsai_from_config(
-    config_settings: typing.Union[dict[str, typing.Any], None],
-) -> typing.Union[dict[str, typing.Any], None]:
+    config_settings: dict[str, typing.Any] | None,
+) -> dict[str, typing.Any] | None:
     """Filter out settings that begin with ``rapidsai.`` to be passed down to the
     underlying backend, because some backends get confused if you pass them options that
     they don't recognize.
@@ -114,7 +114,7 @@ def _get_cuda_suffix() -> str:
 
 
 @lru_cache
-def _get_git_commit() -> typing.Union[str, None]:
+def _get_git_commit() -> str | None:
     """Get the current git commit.
 
     Returns None if git is not in the PATH or if it fails to find the commit.

--- a/tests/test_impls.py
+++ b/tests/test_impls.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 import os.path
@@ -317,15 +317,19 @@ def test_edit_pyproject(
             matrix_entry=matrix,
         )
 
-        with patch(
-            "rapids_build_backend.impls._get_arch",
-            Mock(return_value=arch) if arch is not None else _get_arch,
-        ), patch(
-            "rapids_build_backend.impls._get_cuda_version",
-            Mock(return_value=cuda_version),
-        ), patch(
-            "rapids_build_backend.impls._get_cuda_suffix",
-            _get_cuda_suffix.__wrapped__,
+        with (
+            patch(
+                "rapids_build_backend.impls._get_arch",
+                Mock(return_value=arch) if arch is not None else _get_arch,
+            ),
+            patch(
+                "rapids_build_backend.impls._get_cuda_version",
+                Mock(return_value=cuda_version),
+            ),
+            patch(
+                "rapids_build_backend.impls._get_cuda_suffix",
+                _get_cuda_suffix.__wrapped__,
+            ),
         ):
             if write_dependencies_file:
                 with _edit_pyproject(config):


### PR DESCRIPTION
Fixes #82 

#80 tightened GitHub Actions permissions here as part of https://github.com/rapidsai/build-planning/issues/275, but we missed that the caller at the top of a chain of nested reusable workflow calls is responsible for defining the maximum permissions that any workflows in the chain can use.

This wasn't caught in #80 because PR CI isn't required in this project's branch protections. I've fixed that, and this PR fixes the permissions.

* sets permissions in the top-level workflows
* updates all `pre-commit` hooks with `pre-commit autoupdate`
* bumps minimum Python version to 3.10
