### PR TITLE
update pre-commit hooks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,17 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  # Please keep pr-builder as the top job here
+  pr-builder:
+    needs:
+      - run-checks
+    permissions:
+      checks: write
+      pull-requests: write
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main # zizmor: ignore[unpinned-uses]
+    if: always()
+    with:
+      needs: ${{ toJSON(needs) }}
   run-checks:
     uses: ./.github/workflows/checks-and-builds.yaml
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 exclude: |
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.20.3
+    rev: v1.21.0
     hooks:
       - id: rapids-dependency-file-generator
         args: ["--clean", "--warn-all", "--strict"]
@@ -22,13 +22,13 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.15.20
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.4.3
+    rev: v1.6.0
     hooks:
       - id: verify-copyright
         args: [--fix, --spdx]
@@ -62,7 +62,7 @@ repos:
       - id: shellcheck
         args: ["--severity=warning"]
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.26.1
     hooks:
       - id: zizmor
 


### PR DESCRIPTION
Fixes #84

The branch protection here now enforces that `pr-builder` and `Merge Barriers` must pass for PRs to be mergeable:

<img width="860" height="383" alt="image" src="https://github.com/user-attachments/assets/57d560bd-bab7-4dbb-b75f-27517ddf8718" />

Also updates all pre-commit hooks with `pre-commit autoupdate`, figured I might as well while I'm touching the repo.